### PR TITLE
style: increase fontsize for post published date

### DIFF
--- a/app/(marketing)/blog/blogCard.tsx
+++ b/app/(marketing)/blog/blogCard.tsx
@@ -60,7 +60,7 @@ export default function BlogCard({ post }: BlogCardProps) {
             </div>
           ) : null}
           {post.published_at && (
-            <div className="text-muted-foreground text-sm">
+            <div className="text-muted-foreground text-base">
               {formatDate(post.published_at)}
             </div>
           )}


### PR DESCRIPTION
I think we should increase fontsize for published date in PostItem. 
It looks too small.

Before
![Screenshot 2024-06-10 at 23 17 49](https://github.com/berachain/berachain-ecosystem-blogs/assets/15717476/fc223f08-de55-432f-96a1-7292290c5e1c)

After
![Screenshot 2024-06-10 at 23 17 39](https://github.com/berachain/berachain-ecosystem-blogs/assets/15717476/0e403d73-561d-4419-924a-89bc08ed2afb)

Changed: `text-sm` -> `text-base`